### PR TITLE
Additional compat for older betternether versions

### DIFF
--- a/src/main/java/git/jbredwards/nether_api/mod/common/compat/betternether/BetterNetherHandler.java
+++ b/src/main/java/git/jbredwards/nether_api/mod/common/compat/betternether/BetterNetherHandler.java
@@ -36,7 +36,6 @@ public final class BetterNetherHandler
 {
     @Nonnull static final Set<NetherBiome> GEN_BIOMES = new HashSet<>();
     @Nonnull static final Map<NetherBiome, BiomeBetterNether> BIOME_LOOKUP = new HashMap<>();
-    @Nullable static Field legacyEnabledBiomes;
 
     public static void registerBiomes(@Nonnull final INetherAPIRegistry registry) {
         GEN_BIOMES.forEach(netherBiome -> {
@@ -59,14 +58,8 @@ public final class BetterNetherHandler
             // using a forked version of the mod
             if(biome.netherBiome instanceof WeightedRandom.Item) biome.cachedWeight = ConfigLoader.mustInitBiome(biome.netherBiome) ? biome.netherBiome.itemWeight : 0;
 
-            // using the original mod
-            else {
-                if(legacyEnabledBiomes == null) legacyEnabledBiomes = ObfuscationReflectionHelper.findField(ConfigLoader.class, "registerBiomes");
-                try { biome.cachedWeight = ((boolean[])legacyEnabledBiomes.get(null))[biome.netherBiomeId] ? 1 : 0; }
-
-                // should never pass
-                catch(final IllegalAccessException e) { throw new RuntimeException(e); }
-            }
+            // using the original mod, config disable already handled via biome != null in registerBiomes
+            else biome.cachedWeight = 1;
         }
 
         return biome.cachedWeight;
@@ -75,7 +68,7 @@ public final class BetterNetherHandler
     @SubscribeEvent
     static void registerBiomes(@Nonnull final RegistryEvent.Register<Biome> event) {
         @Nonnull final ObjIntConsumer<NetherBiome> registerAction = (netherBiome, netherBiomeId) -> {
-            if(!biomeIsEnabled(netherBiomeId)) return;
+            if(netherBiome == null) return;
 
             @Nonnull final BiomeBetterNether biome = new BiomeBetterNether(netherBiome, netherBiomeId);
             event.getRegistry().register(biome);
@@ -85,11 +78,11 @@ public final class BetterNetherHandler
         };
 
         // register biomes for gen
-        if(biomeIsEnabled(1)) GEN_BIOMES.add(BiomeRegister.BIOME_GRAVEL_DESERT);
-        if(biomeIsEnabled(2)) GEN_BIOMES.add(BiomeRegister.BIOME_NETHER_JUNGLE);
-        if(biomeIsEnabled(3)) GEN_BIOMES.add(BiomeRegister.BIOME_WART_FOREST);
-        if(biomeIsEnabled(4)) GEN_BIOMES.add(BiomeRegister.BIOME_GRASSLANDS);
-        if(biomeIsEnabled(5)) GEN_BIOMES.add(BiomeRegister.BIOME_MUSHROOM_FOREST);
+        if(BiomeRegister.BIOME_GRAVEL_DESERT != null) GEN_BIOMES.add(BiomeRegister.BIOME_GRAVEL_DESERT);
+        if(BiomeRegister.BIOME_NETHER_JUNGLE != null) GEN_BIOMES.add(BiomeRegister.BIOME_NETHER_JUNGLE);
+        if(BiomeRegister.BIOME_WART_FOREST != null) GEN_BIOMES.add(BiomeRegister.BIOME_WART_FOREST);
+        if(BiomeRegister.BIOME_GRASSLANDS != null) GEN_BIOMES.add(BiomeRegister.BIOME_GRASSLANDS);
+        if(BiomeRegister.BIOME_MUSHROOM_FOREST != null) GEN_BIOMES.add(BiomeRegister.BIOME_MUSHROOM_FOREST);
 
         // register biomes
         registerAction.accept(BiomeRegister.BIOME_EMPTY_NETHER, 0);
@@ -102,39 +95,18 @@ public final class BetterNetherHandler
         registerAction.accept(BiomeRegister.BIOME_WART_FOREST_EDGE, 7);
         registerAction.accept(BiomeRegister.BIOME_BONE_REEF, 8);
         registerAction.accept(BiomeRegister.BIOME_POOR_GRASSLANDS, 9);
-
-        betterNetherBiomeEnabledConfig = null;
     }
 
     // exists because this mod adds BetterNether biomes as real biomes
     public static void init() {
         // fix fireflies
         Biomes.HELL.getSpawnableList(EnumCreatureType.AMBIENT).removeIf(entry -> entry.entityClass == EntityFirefly.class);
-        EntityRegistry.addSpawn(EntityFirefly.class, 100, 5, 10, EnumCreatureType.AMBIENT,
-                getBiomeFromLookup(BiomeRegister.BIOME_GRASSLANDS), getBiomeFromLookup(BiomeRegister.BIOME_NETHER_JUNGLE)
-        );
+        if(BiomeRegister.BIOME_GRASSLANDS != null) EntityRegistry.addSpawn(EntityFirefly.class, 100, 5, 10, EnumCreatureType.AMBIENT, getBiomeFromLookup(BiomeRegister.BIOME_GRASSLANDS));
+        if(BiomeRegister.BIOME_NETHER_JUNGLE != null) EntityRegistry.addSpawn(EntityFirefly.class, 100, 5, 10, EnumCreatureType.AMBIENT, getBiomeFromLookup(BiomeRegister.BIOME_NETHER_JUNGLE));
 
         // remove ghasts from biomes that have cacti, as to prevent lots of really annoying damage sounds from playing
-        getBiomeFromLookup(BiomeRegister.BIOME_GRAVEL_DESERT).getSpawnableList(EnumCreatureType.MONSTER)
-                .removeIf(entry -> EntityGhast.class.isAssignableFrom(entry.entityClass));
-    }
-
-    //The following is only necessary in older versions of BetterNether
-    //Cache for faster access
-    private static boolean[] betterNetherBiomeEnabledConfig = null;
-    private static boolean biomeIsEnabled(int id) {
-        if (betterNetherBiomeEnabledConfig == null) {
-            try {
-                Field field = ConfigLoader.class.getDeclaredField("registerBiomes");
-                field.setAccessible(true);
-                betterNetherBiomeEnabledConfig = (boolean[]) field.get(null);
-            } catch (Exception ignored) {
-                //In other versions of BetterNether the targeted field will just not exist
-                betterNetherBiomeEnabledConfig = new boolean[]{true};
-            }
-        }
-
-        if (id < 0 || id >= betterNetherBiomeEnabledConfig.length) return true;
-        else return betterNetherBiomeEnabledConfig[id];
+        if(BiomeRegister.BIOME_GRAVEL_DESERT != null)
+            getBiomeFromLookup(BiomeRegister.BIOME_GRAVEL_DESERT).getSpawnableList(EnumCreatureType.MONSTER)
+                    .removeIf(entry -> EntityGhast.class.isAssignableFrom(entry.entityClass));
     }
 }

--- a/src/main/java/git/jbredwards/nether_api/mod/common/compat/betternether/BetterNetherHandler.java
+++ b/src/main/java/git/jbredwards/nether_api/mod/common/compat/betternether/BetterNetherHandler.java
@@ -75,6 +75,8 @@ public final class BetterNetherHandler
     @SubscribeEvent
     static void registerBiomes(@Nonnull final RegistryEvent.Register<Biome> event) {
         @Nonnull final ObjIntConsumer<NetherBiome> registerAction = (netherBiome, netherBiomeId) -> {
+            if(!biomeIsEnabled(netherBiomeId)) return;
+
             @Nonnull final BiomeBetterNether biome = new BiomeBetterNether(netherBiome, netherBiomeId);
             event.getRegistry().register(biome);
 
@@ -83,11 +85,11 @@ public final class BetterNetherHandler
         };
 
         // register biomes for gen
-        GEN_BIOMES.add(BiomeRegister.BIOME_GRAVEL_DESERT);
-        GEN_BIOMES.add(BiomeRegister.BIOME_NETHER_JUNGLE);
-        GEN_BIOMES.add(BiomeRegister.BIOME_WART_FOREST);
-        GEN_BIOMES.add(BiomeRegister.BIOME_GRASSLANDS);
-        GEN_BIOMES.add(BiomeRegister.BIOME_MUSHROOM_FOREST);
+        if(biomeIsEnabled(1)) GEN_BIOMES.add(BiomeRegister.BIOME_GRAVEL_DESERT);
+        if(biomeIsEnabled(2)) GEN_BIOMES.add(BiomeRegister.BIOME_NETHER_JUNGLE);
+        if(biomeIsEnabled(3)) GEN_BIOMES.add(BiomeRegister.BIOME_WART_FOREST);
+        if(biomeIsEnabled(4)) GEN_BIOMES.add(BiomeRegister.BIOME_GRASSLANDS);
+        if(biomeIsEnabled(5)) GEN_BIOMES.add(BiomeRegister.BIOME_MUSHROOM_FOREST);
 
         // register biomes
         registerAction.accept(BiomeRegister.BIOME_EMPTY_NETHER, 0);
@@ -100,6 +102,8 @@ public final class BetterNetherHandler
         registerAction.accept(BiomeRegister.BIOME_WART_FOREST_EDGE, 7);
         registerAction.accept(BiomeRegister.BIOME_BONE_REEF, 8);
         registerAction.accept(BiomeRegister.BIOME_POOR_GRASSLANDS, 9);
+
+        betterNetherBiomeEnabledConfig = null;
     }
 
     // exists because this mod adds BetterNether biomes as real biomes
@@ -113,5 +117,24 @@ public final class BetterNetherHandler
         // remove ghasts from biomes that have cacti, as to prevent lots of really annoying damage sounds from playing
         getBiomeFromLookup(BiomeRegister.BIOME_GRAVEL_DESERT).getSpawnableList(EnumCreatureType.MONSTER)
                 .removeIf(entry -> EntityGhast.class.isAssignableFrom(entry.entityClass));
+    }
+
+    //The following is only necessary in older versions of BetterNether
+    //Cache for faster access
+    private static boolean[] betterNetherBiomeEnabledConfig = null;
+    private static boolean biomeIsEnabled(int id) {
+        if (betterNetherBiomeEnabledConfig == null) {
+            try {
+                Field field = ConfigLoader.class.getDeclaredField("registerBiomes");
+                field.setAccessible(true);
+                betterNetherBiomeEnabledConfig = (boolean[]) field.get(null);
+            } catch (Exception ignored) {
+                //In other versions of BetterNether the targeted field will just not exist
+                betterNetherBiomeEnabledConfig = new boolean[]{true};
+            }
+        }
+
+        if (id < 0 || id >= betterNetherBiomeEnabledConfig.length) return true;
+        else return betterNetherBiomeEnabledConfig[id];
     }
 }


### PR DESCRIPTION
If some of the BetterNether biomes are disabled in older versions of BN (e.g. in RLCraft), using NetherAPI will crash at startup. This solves the problem without changing behavior for newer BetterNether versions.