### PR TITLE
fix compatibility for forge+bukkit servers

### DIFF
--- a/src/main/java/git/jbredwards/nether_api/mod/asm/transformers/vanilla/TransformerNetHandlerPlayClient.java
+++ b/src/main/java/git/jbredwards/nether_api/mod/asm/transformers/vanilla/TransformerNetHandlerPlayClient.java
@@ -93,7 +93,7 @@ public final class TransformerNetHandlerPlayClient implements ITransformer
             case "net.minecraft.server.management.PlayerList":
             case "net.minecraft.server.MinecraftServer": {
                 return transformMethod(basicClass, method -> method.name.equals(DEOBFUSCATED ? "createPlayerForUser" : "func_148545_a") || method.name.equals(DEOBFUSCATED ? "initialWorldChunkLoad" : "func_71222_d"), (method, insn) -> {
-                    if(insn instanceof MethodInsnNode && (((MethodInsnNode)insn).name.equals("getWorld") || ((MethodInsnNode)insn).name.equals("func_71218_a"))) {
+                    if(insn instanceof MethodInsnNode && (((MethodInsnNode)insn).name.equals("getWorld") || ((MethodInsnNode)insn).name.equals("func_71218_a")) && ((MethodInsnNode)insn).desc.startsWith("(I)L")) {
                         method.instructions.insertBefore(insn, "net.minecraft.server.management.PlayerList".equals(transformedName) ? new VarInsnNode(ALOAD, 1) : new InsnNode(ACONST_NULL));
                         method.instructions.insertBefore(insn, genHookMethod("getSpawnDim", "(ILcom/mojang/authlib/GameProfile;)I"));
                     }


### PR DESCRIPTION
we should check the arg for method "getWorld", because we need to call WorldLoadEvent for bukkit with other "getWorld" method
```java
    public void initialWorldChunkLoad()
    {
        int i = 16;
        int j = 4;
        int k = 192;
        int l = 625;
        int i1 = 0;
        this.setUserMessage("menu.generatingTerrain");
        int j1 = 0;
        LOGGER.info("Preparing start region for level 0");
        WorldServer worldserver = net.minecraftforge.common.DimensionManager.getWorld(j1);
        BlockPos blockpos = worldserver.getSpawnPoint();
        long k1 = getCurrentTimeMillis();

        for (int l1 = -192; l1 <= 192 && this.isServerRunning(); l1 += 16)
        {
            for (int i2 = -192; i2 <= 192 && this.isServerRunning(); i2 += 16)
            {
                long j2 = getCurrentTimeMillis();

                if (j2 - k1 > 1000L)
                {
                    this.outputPercentRemaining("Preparing spawn area", i1 * 100 / 625);
                    k1 = j2;
                }

                ++i1;
                worldserver.getChunkProvider().provideChunk(blockpos.getX() + l1 >> 4, blockpos.getZ() + i2 >> 4);
            }
        }

        for (WorldServer world : this.worldServerList) { // here is a bukkit code
            this.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(world.getWorld()));
        }

        this.clearCurrentTask();
    }
```